### PR TITLE
Cleanup envvar names

### DIFF
--- a/src/build-llvm/CMakeLists.txt
+++ b/src/build-llvm/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 3.10.0)
 
-project(qirlib_external)
+project(llvm_build_external)
 include(ExternalProject)
 
 # Environment variables

--- a/src/build-llvm/Cargo.toml
+++ b/src/build-llvm/Cargo.toml
@@ -42,7 +42,7 @@ no-llvm-linking = []
 
 # let us do the llvm linking
 # internal-llvm-linking is marker used in the cfg checks
-llvm14-0-qirlib-llvm-linking = ["llvm14-0", "internal-llvm-linking", "llvm-sys-140/disable-alltargets-init", "llvm-sys-140/no-llvm-linking"]
+llvm14-0-rsql-llvm-linking = ["llvm14-0", "internal-llvm-linking", "llvm-sys-140/disable-alltargets-init", "llvm-sys-140/no-llvm-linking"]
 
 internal-llvm-linking = []
 download-llvm = []

--- a/src/build-llvm/build.rs
+++ b/src/build-llvm/build.rs
@@ -53,28 +53,28 @@ compile_error!(
 
 // Make sure one of the linking features is used
 #[cfg(all(
-  not(any(feature = "qirlib-llvm-linking")),
+  not(any(feature = "rsql-llvm-linking")),
   not(any(feature = "external-llvm-linking")),
   not(any(feature = "no-llvm-linking")),
 ))]
-compile_error!("One of the features `qirlib/qirlib-llvm-linking`, `qirlib/external-llvm-linking`, and `qirlib/no-llvm-linking` must be used exclusive.");
+compile_error!("One of the features `rsql/rsql-llvm-linking`, `rsql/external-llvm-linking`, and `rsql/no-llvm-linking` must be used exclusive.");
 
 // Make sure only one linking option is used.
 #[cfg(any(
   all(
-    feature = "qirlib-llvm-linking",
+    feature = "rsql-llvm-linking",
     any(feature = "external-llvm-linking", feature = "no-llvm-linking")
   ),
   all(
     feature = "external-llvm-linking",
-    any(feature = "qirlib-llvm-linking", feature = "no-llvm-linking")
+    any(feature = "rsql-llvm-linking", feature = "no-llvm-linking")
   ),
   all(
     feature = "no-llvm-linking",
-    any(feature = "qirlib-llvm-linking", feature = "external-llvm-linking")
+    any(feature = "rsql-llvm-linking", feature = "external-llvm-linking")
   ),
 ))]
-compile_error!("Features `qirlib/qirlib-llvm-linking`, `qirlib/external-llvm-linking`, and `qirlib/no-llvm-linking` are mutually exclusive.");
+compile_error!("Features `rsql/rsql-llvm-linking`, `rsql/external-llvm-linking`, and `rsql/no-llvm-linking` are mutually exclusive.");
 
 // if we are building or downloading, we cannot be externally linking
 #[cfg(any(
@@ -87,7 +87,7 @@ compile_error!("Features `qirlib/qirlib-llvm-linking`, `qirlib/external-llvm-lin
     any(feature = "build-llvm", feature = "external-llvm-linking")
   ),
 ))]
-compile_error!("Features `qirlib/build-llvm` and `qirlib/download-llvm` are mutually exclusive.");
+compile_error!("Features `rsql/build-llvm` and `rsql/download-llvm` are mutually exclusive.");
 
 fn main() -> Result<(), Box<dyn Error>> {
   println!("cargo:rerun-if-changed=build.rs");
@@ -124,7 +124,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("Building llvm");
     compile_llvm()?;
   }
-  if cfg!(feature = "qirlib-llvm-linking") {
+  if cfg!(feature = "rsql-llvm-linking") {
     println!("Linking llvm");
     link_llvm();
     let build_dir = get_build_dir()?;

--- a/src/rasqal/README.md
+++ b/src/rasqal/README.md
@@ -9,7 +9,7 @@ Some of the key things this approach enables:
 2. Enabling hybrid algorithms to be run on machines and tools with only a gate-level API available. This includes QASM API's if you use its simulation framework.
 3. Lots of optimization potential when passed large amounts of classical context that a quantum algorithm uses to accentuate its own execution.
 
-We also have a [full feature list and quick intro to its concepts](https://github.com/oqc-community/Rasqal/blob/develop/docs/features_and_concepts.py) as well as a [draft paper](https://github.com/oqc-community/rasqal/blob/develop/docs/Rasqal%20Draft%20v2.pdf) that covers its internals in excruciating detail.
+We also have a [full feature list and quick intro to its concepts](https://github.com/oqc-community/rasqal/blob/develop/features_and_concepts.md) as well as a [draft paper](https://github.com/oqc-community/rasqal/blob/develop/docs/Rasqal%20Draft%20v2.pdf) that covers its internals in excruciating detail.
 
 If you have any features or ideas you'd like to see implemented feel free to raise a [feature request](https://github.com/oqc-community/Rasqal/issues/new?assignees=&labels=enhancement&projects=&template=feature_request.md&title=)!
 


### PR DESCRIPTION
While the projects were inherited from other repos the env variables should reflect this one.