### PR TITLE
Define on-release event type

### DIFF
--- a/.github/workflows/deploy-wheels.yml
+++ b/.github/workflows/deploy-wheels.yml
@@ -2,6 +2,7 @@ name: deploy-wheels
 
 on:
   release:
+    types: [released]
 
 jobs:
   deploy:


### PR DESCRIPTION
When releasing for some reason it was attempting to deploy three times, I assume for created/released/published. Just limit to one of these,