### PR TITLE
Increase Rust version to 0.1.6

### DIFF
--- a/src/rasqal/Cargo.toml
+++ b/src/rasqal/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["John Dumbell"]
 name = "rasqal"
-version = "0.1.0"
+version = "0.1.6"
 edition = "2021"
 license = "BSD-3-Clause"
 description = ""

--- a/src/rasqal/src/evaluator.rs
+++ b/src/rasqal/src/evaluator.rs
@@ -1399,8 +1399,7 @@ impl QIREvaluator {
       }
 
       // Output recording doesn't matter for us.
-      "__quantum__rt__tuple_record_output" | "__quantum__rt__array_record_output" => {
-      }
+      "__quantum__rt__tuple_record_output" | "__quantum__rt__array_record_output" => {}
 
       // Bigint support that hopefully we'll just be able to ignore.
       "__quantum__rt__bigint_add"


### PR DESCRIPTION
Doesn't come up since we don't deploy as a crate, but may as well keep in lock-step.