### PR TITLE
Updating codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jfriel-oqc @keriksson-rosenqvist @owen-oqc @hamidelmaazouz @chemix-lunacy @bgsach
+* @owen-oqc @chemix-lunacy


### PR DESCRIPTION
Previously used to easily keep people abreast of what's going on, now moving to a more traditional usage of code ownership.